### PR TITLE
feat: add backup_db and restore_db management commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 
 COPY ru-trust-bundle.pem /usr/local/share/ca-certificates/ru-trust-bundle.crt
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates \
+    && apt-get install -y --no-install-recommends ca-certificates postgresql-client-15 \
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TAG      ?= latest
 
 FULL_IMAGE = $(REGISTRY)/$(IMAGE):$(TAG)
 
-.PHONY: build push build-push login
+.PHONY: build push build-push login backup restore
 
 build:
 	$(PODMAN) build -t $(FULL_IMAGE) --platform linux/amd64 .
@@ -17,3 +17,9 @@ build-push: build push
 
 login:
 	$(PODMAN) login $(REGISTRY)
+
+backup:
+	docker compose -f docker-compose_v2.yml exec kolco24_django python manage.py backup_db
+
+restore:
+	docker compose -f docker-compose_v2.yml exec -it kolco24_django python manage.py restore_db --latest

--- a/deploy/kolco24.env.example
+++ b/deploy/kolco24.env.example
@@ -43,3 +43,7 @@ VTB_RETURN_URL_BASE=
 
 # Google Docs
 GOOGLE_DOCS_KEY=
+
+# Backup
+BACKUP_DIR=/app/backups
+BACKUP_RETENTION_DAYS=30

--- a/docker-compose_v2.yml
+++ b/docker-compose_v2.yml
@@ -30,11 +30,34 @@ services:
       - ./deploy/kolco24.env
     volumes:
       - media:/app/media
+      - backups:/app/backups
     depends_on:
       kolco24_migrate:
         condition: service_completed_successfully
     networks:
       - nginx_network
+      - kolco24_default
+
+  kolco24_backup:
+    image: ${KOLCO24_IMAGE:?KOLCO24_IMAGE is required}
+    container_name: kolco24_backup
+    restart: unless-stopped
+    command:
+      - /bin/sh
+      - -c
+      - |
+        while true; do
+          python manage.py backup_db
+          sleep 86400
+        done
+    env_file:
+      - ./deploy/kolco24.env
+    volumes:
+      - backups:/app/backups
+    depends_on:
+      kolco24_migrate:
+        condition: service_completed_successfully
+    networks:
       - kolco24_default
 
   kolco24_runmailer:
@@ -75,3 +98,4 @@ networks:
 volumes:
   postgres-data:
   media:
+  backups:

--- a/docs/plans/backup-restore.md
+++ b/docs/plans/backup-restore.md
@@ -1,0 +1,168 @@
+# План: команды backup_db и restore_db
+
+## Context
+
+Нужны Django management commands для создания и восстановления бэкапов PostgreSQL.
+Бэкапы хранятся локально в Docker volume. Регулярные бэкапы — через отдельный Docker-сервис с cron.
+
+---
+
+## Изменяемые файлы
+
+| Файл | Что меняем |
+|------|-----------|
+| `Dockerfile` | Добавить `postgresql-client-15` в apt-get |
+| `docker-compose_v2.yml` | Добавить сервис `kolco24_backup` и volume `backups` |
+| `deploy/kolco24.env.example` | Добавить переменные `BACKUP_DIR`, `BACKUP_RETENTION_DAYS` |
+| `src/website/management/commands/backup_db.py` | **Новый файл** |
+| `src/website/management/commands/restore_db.py` | **Новый файл** |
+| `Makefile` | Добавить таргеты `backup` и `restore` |
+
+---
+
+## Шаг 1 — Dockerfile
+
+Добавить `postgresql-client-15` в `apt-get install` (совпадает с версией prod-БД `postgres:15`):
+
+```dockerfile
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates postgresql-client-15 \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+---
+
+## Шаг 2 — backup_db management command
+
+`src/website/management/commands/backup_db.py`
+
+**Аргументы:**
+- `--output-dir` — переопределить директорию (по умолчанию `BACKUP_DIR` env или `/app/backups`)
+- нет флагов — просто запускает дамп
+
+**Логика:**
+1. Прочитать DB-настройки из `django.conf.settings.DATABASES["default"]`
+2. Создать директорию если не существует
+3. Сформировать имя файла: `kolco24_YYYY-MM-DD_HHMMSS.dump`
+4. Запустить `pg_dump -Fc -h HOST -p PORT -U USER -d DBNAME -f /path/file.dump`
+   - Пароль передавать через `env["PGPASSWORD"]` в `subprocess.run`, не через аргументы CLI
+5. Проверить returncode, вывести размер файла
+6. Удалить файлы старше `BACKUP_RETENTION_DAYS` (default: 30) из директории
+7. Вывести итог в `self.stdout`
+
+---
+
+## Шаг 3 — restore_db management command
+
+`src/website/management/commands/restore_db.py`
+
+**Аргументы:**
+- `backup_file` — позиционный, путь к файлу (необязательный)
+- `--latest` — автоматически найти последний файл в `BACKUP_DIR`
+- `--no-confirm` — пропустить интерактивное подтверждение (для скриптов)
+
+**Логика:**
+1. Разрешить файл: явный путь > `--latest` (найти последний `*.dump` в `BACKUP_DIR`)
+2. Проверить что файл существует
+3. Запросить подтверждение (если не `--no-confirm` и `sys.stdin.isatty()`)
+4. Запустить `pg_restore --clean --if-exists --no-owner -Fc -h HOST -p PORT -U USER -d DBNAME /path/file.dump`
+   - `--clean --if-exists` — очищает объекты внутри БД без DROP DATABASE (работает пока приложение запущено)
+5. Проверить returncode, вывести результат
+
+---
+
+## Шаг 4 — docker-compose_v2.yml
+
+**Новый сервис `kolco24_backup`** — запускает `backup_db` раз в сутки через shell-loop:
+
+```yaml
+kolco24_backup:
+  image: ${KOLCO24_IMAGE:?KOLCO24_IMAGE is required}
+  container_name: kolco24_backup
+  restart: unless-stopped
+  command:
+    - /bin/sh
+    - -c
+    - |
+      while true; do
+        python manage.py backup_db
+        sleep 86400
+      done
+  env_file:
+    - ./deploy/kolco24.env
+  volumes:
+    - backups:/app/backups
+  depends_on:
+    kolco24_migrate:
+      condition: service_completed_successfully
+  networks:
+    - kolco24_default
+```
+
+**Новый volume** в секции `volumes:`:
+```yaml
+backups:
+```
+
+**Также смонтировать `backups` в `kolco24_web`** — чтобы можно было запустить `restore_db` через `docker exec`:
+```yaml
+volumes:
+  - media:/app/media
+  - backups:/app/backups
+```
+
+---
+
+## Шаг 5 — deploy/kolco24.env.example
+
+Добавить секцию:
+
+```
+# Backup
+BACKUP_DIR=/app/backups
+BACKUP_RETENTION_DAYS=30
+```
+
+---
+
+## Шаг 6 — Makefile
+
+```makefile
+backup:
+	docker compose -f docker-compose_v2.yml exec kolco24_django python manage.py backup_db
+
+restore:
+	docker compose -f docker-compose_v2.yml exec -it kolco24_django python manage.py restore_db --latest
+```
+
+> Имя контейнера `kolco24_django` — из `container_name` в docker-compose_v2.yml.
+
+---
+
+## Использование
+
+```bash
+# Ручной бэкап
+python manage.py backup_db
+python manage.py backup_db --output-dir /tmp/backups
+
+# Восстановление
+python manage.py restore_db --latest               # последний бэкап (с подтверждением)
+python manage.py restore_db path/to/file.dump      # конкретный файл
+python manage.py restore_db --latest --no-confirm  # без вопросов (в скриптах)
+
+# Через make (production)
+make backup
+make restore
+```
+
+---
+
+## Проверка
+
+1. `make build-push` — убедиться что `pg_dump` доступен в образе: `docker run ... pg_dump --version`
+2. Запустить `python manage.py backup_db` — файл появляется в `BACKUP_DIR`, размер > 0
+3. Запустить `python manage.py restore_db --latest` — восстановление проходит без ошибок
+4. Запустить `docker compose up` — убедиться что `kolco24_backup` стартует и делает первый дамп
+5. Проверить retention: создать старые файлы вручную, запустить `backup_db` повторно, старые файлы удалены

--- a/src/website/management/commands/backup_db.py
+++ b/src/website/management/commands/backup_db.py
@@ -1,6 +1,5 @@
 import os
 import subprocess
-import sys
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -39,7 +38,20 @@ class Command(BaseCommand):
 
         env = {**os.environ, "PGPASSWORD": password}
         result = subprocess.run(
-            ["pg_dump", "-Fc", "-h", host, "-p", port, "-U", user, "-d", name, "-f", filepath],
+            [
+                "pg_dump",
+                "-Fc",
+                "-h",
+                host,
+                "-p",
+                port,
+                "-U",
+                user,
+                "-d",
+                name,
+                "-f",
+                filepath,
+            ],
             env=env,
             capture_output=True,
             text=True,
@@ -49,7 +61,9 @@ class Command(BaseCommand):
             raise CommandError(f"pg_dump failed:\n{result.stderr}")
 
         size = Path(filepath).stat().st_size
-        self.stdout.write(self.style.SUCCESS(f"Backup created: {filepath} ({size:,} bytes)"))
+        self.stdout.write(
+            self.style.SUCCESS(f"Backup created: {filepath} ({size:,} bytes)")
+        )
 
         self._prune_old_backups(output_dir, retention_days)
 
@@ -61,4 +75,6 @@ class Command(BaseCommand):
                 path.unlink()
                 pruned += 1
         if pruned:
-            self.stdout.write(f"Pruned {pruned} backup(s) older than {retention_days} days.")
+            self.stdout.write(
+                f"Pruned {pruned} backup(s) older than {retention_days} days."
+            )

--- a/src/website/management/commands/backup_db.py
+++ b/src/website/management/commands/backup_db.py
@@ -1,0 +1,64 @@
+import os
+import subprocess
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+
+class Command(BaseCommand):
+    help = "Dump PostgreSQL database to a compressed backup file."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--output-dir",
+            default=None,
+            help="Directory to save the backup (overrides BACKUP_DIR env var).",
+        )
+
+    def handle(self, *args, **options):
+        db = settings.DATABASES["default"]
+        host = db.get("HOST", "localhost")
+        port = str(db.get("PORT", "5432"))
+        name = db["NAME"]
+        user = db["USER"]
+        password = db.get("PASSWORD", "")
+
+        output_dir = options["output_dir"] or os.getenv("BACKUP_DIR", "/app/backups")
+        retention_days = int(os.getenv("BACKUP_RETENTION_DAYS", "30"))
+
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+        timestamp = datetime.now().strftime("%Y-%m-%d_%H%M%S")
+        filename = f"kolco24_{timestamp}.dump"
+        filepath = os.path.join(output_dir, filename)
+
+        self.stdout.write(f"Backing up database '{name}' to {filepath} ...")
+
+        env = {**os.environ, "PGPASSWORD": password}
+        result = subprocess.run(
+            ["pg_dump", "-Fc", "-h", host, "-p", port, "-U", user, "-d", name, "-f", filepath],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        if result.returncode != 0:
+            raise CommandError(f"pg_dump failed:\n{result.stderr}")
+
+        size = Path(filepath).stat().st_size
+        self.stdout.write(self.style.SUCCESS(f"Backup created: {filepath} ({size:,} bytes)"))
+
+        self._prune_old_backups(output_dir, retention_days)
+
+    def _prune_old_backups(self, output_dir, retention_days):
+        cutoff = datetime.now() - timedelta(days=retention_days)
+        pruned = 0
+        for path in Path(output_dir).glob("*.dump"):
+            if datetime.fromtimestamp(path.stat().st_mtime) < cutoff:
+                path.unlink()
+                pruned += 1
+        if pruned:
+            self.stdout.write(f"Pruned {pruned} backup(s) older than {retention_days} days.")

--- a/src/website/management/commands/restore_db.py
+++ b/src/website/management/commands/restore_db.py
@@ -92,7 +92,8 @@ class Command(BaseCommand):
             return dumps[-1]
 
         raise CommandError(
-            "Provide a backup file path or use --latest to restore the most recent backup."
+            "Provide a backup file path or use "
+            "--latest to restore the most recent backup."
         )
 
     def _confirm(self, filepath, db_name):
@@ -104,7 +105,8 @@ class Command(BaseCommand):
         )
         if not sys.stdin.isatty():
             raise CommandError(
-                "Restore requires confirmation. Pass --no-confirm to skip in non-interactive mode."
+                "Restore requires confirmation. "
+                "Pass --no-confirm to skip in non-interactive mode."
             )
         answer = input("Type 'yes' to continue: ").strip().lower()
         if answer != "yes":

--- a/src/website/management/commands/restore_db.py
+++ b/src/website/management/commands/restore_db.py
@@ -1,0 +1,100 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+
+class Command(BaseCommand):
+    help = "Restore PostgreSQL database from a backup file."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "backup_file",
+            nargs="?",
+            help="Path to the backup file to restore.",
+        )
+        parser.add_argument(
+            "--latest",
+            action="store_true",
+            help="Restore the most recent backup from BACKUP_DIR.",
+        )
+        parser.add_argument(
+            "--no-confirm",
+            action="store_true",
+            help="Skip the confirmation prompt (useful in scripts).",
+        )
+
+    def handle(self, *args, **options):
+        filepath = self._resolve_file(options)
+
+        db = settings.DATABASES["default"]
+        host = db.get("HOST", "localhost")
+        port = str(db.get("PORT", "5432"))
+        name = db["NAME"]
+        user = db["USER"]
+        password = db.get("PASSWORD", "")
+
+        if not options["no_confirm"]:
+            self._confirm(filepath, name)
+
+        self.stdout.write(f"Restoring '{name}' from {filepath} ...")
+
+        env = {**os.environ, "PGPASSWORD": password}
+        result = subprocess.run(
+            [
+                "pg_restore",
+                "--clean", "--if-exists", "--no-owner",
+                "-Fc",
+                "-h", host, "-p", port, "-U", user, "-d", name,
+                str(filepath),
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        if result.returncode != 0:
+            # pg_restore may emit non-fatal warnings to stderr and still exit 0,
+            # but a non-zero exit means something actually failed.
+            raise CommandError(f"pg_restore failed:\n{result.stderr}")
+
+        if result.stderr:
+            self.stderr.write(result.stderr)
+
+        self.stdout.write(self.style.SUCCESS("Restore completed successfully."))
+
+    def _resolve_file(self, options):
+        if options["backup_file"]:
+            path = Path(options["backup_file"])
+            if not path.exists():
+                raise CommandError(f"File not found: {path}")
+            return path
+
+        if options["latest"]:
+            backup_dir = os.getenv("BACKUP_DIR", "/app/backups")
+            dumps = sorted(Path(backup_dir).glob("*.dump"), key=lambda p: p.stat().st_mtime)
+            if not dumps:
+                raise CommandError(f"No .dump files found in {backup_dir}")
+            return dumps[-1]
+
+        raise CommandError(
+            "Provide a backup file path or use --latest to restore the most recent backup."
+        )
+
+    def _confirm(self, filepath, db_name):
+        self.stderr.write(
+            self.style.WARNING(
+                f"\nWARNING: This will overwrite the database '{db_name}' "
+                f"with data from:\n  {filepath}\n"
+            )
+        )
+        if not sys.stdin.isatty():
+            raise CommandError(
+                "Restore requires confirmation. Pass --no-confirm to skip in non-interactive mode."
+            )
+        answer = input("Type 'yes' to continue: ").strip().lower()
+        if answer != "yes":
+            raise CommandError("Restore cancelled.")

--- a/src/website/management/commands/restore_db.py
+++ b/src/website/management/commands/restore_db.py
@@ -46,9 +46,18 @@ class Command(BaseCommand):
         result = subprocess.run(
             [
                 "pg_restore",
-                "--clean", "--if-exists", "--no-owner",
+                "--clean",
+                "--if-exists",
+                "--no-owner",
                 "-Fc",
-                "-h", host, "-p", port, "-U", user, "-d", name,
+                "-h",
+                host,
+                "-p",
+                port,
+                "-U",
+                user,
+                "-d",
+                name,
                 str(filepath),
             ],
             env=env,
@@ -75,7 +84,9 @@ class Command(BaseCommand):
 
         if options["latest"]:
             backup_dir = os.getenv("BACKUP_DIR", "/app/backups")
-            dumps = sorted(Path(backup_dir).glob("*.dump"), key=lambda p: p.stat().st_mtime)
+            dumps = sorted(
+                Path(backup_dir).glob("*.dump"), key=lambda p: p.stat().st_mtime
+            )
             if not dumps:
                 raise CommandError(f"No .dump files found in {backup_dir}")
             return dumps[-1]


### PR DESCRIPTION
- New `backup_db` command: pg_dump to local volume with auto-pruning (BACKUP_RETENTION_DAYS)
- New `restore_db` command: pg_restore with --latest flag and interactive confirmation
- Add `kolco24_backup` Docker service for daily automated backups (sleep 86400 loop)
- Add `backups` volume, mount in web and backup services
- Add postgresql-client-15 to Dockerfile
- Add make backup / make restore targets
- Add BACKUP_DIR, BACKUP_RETENTION_DAYS to env.example
- Add docs/plans/backup-restore.md