### PR TITLE
Show "мест нет" in category badges when race is full

### DIFF
--- a/src/apps/race/tests.py
+++ b/src/apps/race/tests.py
@@ -1393,6 +1393,32 @@ def test_race_page_renders_sold_out_badge(client):
 
 
 @pytest.mark.django_db
+def test_race_page_category_badge_sold_out_when_race_full():
+    """Race-level limit reached → every category badge reads «мест нет».
+
+    The category still has free slots within its own limit, but the race is
+    full, so registration is impossible — the per-category badge must mirror
+    that (``remaining`` forced to 0), not show «осталось K из L».
+    """
+    owner = User.objects.create_user(
+        username="rp4", password="p", email="rp4@example.com"
+    )
+    race = _make_race(slug="racefull-cat", code="rfc")
+    race.people_limit = 4
+    race.save(update_fields=["people_limit"])
+    cat = _make_category(race)
+    cat.people_limit = 20  # plenty of room in the category itself
+    cat.save(update_fields=["people_limit"])
+    _make_team(owner, cat, paid_people=4)  # fills the race
+
+    context = RacePageView.build_context(race)
+
+    assert context["race_remaining"] == 0
+    # Category alone would have 16 free, but the race is full → forced to 0.
+    assert context["categories"][0].remaining == 0
+
+
+@pytest.mark.django_db
 def test_race_page_category_card_shows_labelled_stats(client):
     """Category card states teams and participants in their own units.
 

--- a/src/apps/race/views.py
+++ b/src/apps/race/views.py
@@ -69,11 +69,22 @@ class RacePageView(View):
         # «N команд · M участников» и бейджа «осталось K из L / мест нет».
         # ``remaining`` выводится из уже посчитанного ``people``, чтобы не
         # дёргать ``people_count()`` повторно внутри ``remaining_people()``.
+        race_remaining = race.remaining_people()
+        # Когда исчерпан лимит всей гонки, регистрация невозможна ни в одной
+        # категории — форсируем ``remaining = 0`` во всех категориях, чтобы
+        # бейдж показал «мест нет» даже там, где у категории свой лимит ещё не
+        # выбран (или его нет вовсе). 0 → ветка «мест нет» в шаблоне.
+        race_full = race_remaining is not None and race_remaining <= 0
         for cat in categories:
             cat.people = cat.people_count()
-            cat.remaining = (
-                None if not cat.people_limit else max(0, cat.people_limit - cat.people)
-            )
+            if race_full:
+                cat.remaining = 0
+            else:
+                cat.remaining = (
+                    None
+                    if not cat.people_limit
+                    else max(0, cat.people_limit - cat.people)
+                )
         news_qs = NewsPost.objects.filter(race=race).order_by("-publication_date")
         news_count = news_qs.count()
         news_list = list(news_qs[:10])
@@ -87,7 +98,7 @@ class RacePageView(View):
             "reg_upcoming": race.reg_status == RegStatus.UPCOMING,
             "race_team_count": race.team_count(),
             "race_people_count": race.people_count(),
-            "race_remaining": race.remaining_people(),
+            "race_remaining": race_remaining,
         }
         context["can_edit_race"] = bool(user is not None and can_edit_race(user, race))
         if user is not None and is_race_admin(user, race):

--- a/src/apps/race/views.py
+++ b/src/apps/race/views.py
@@ -65,19 +65,15 @@ class RacePageView(View):
     @staticmethod
     def build_context(race, user=None):
         categories = list(_categories_with_team_count(race))
-        # Занятость (paid_people) и свободные слоты на категорию — для строки
-        # «N команд · M участников» и бейджа «осталось K из L / мест нет».
-        # ``remaining`` выводится из уже посчитанного ``people``, чтобы не
-        # дёргать ``people_count()`` повторно внутри ``remaining_people()``.
         race_remaining = race.remaining_people()
-        # Когда исчерпан лимит всей гонки, регистрация невозможна ни в одной
-        # категории — форсируем ``remaining = 0`` во всех категориях, чтобы
-        # бейдж показал «мест нет» даже там, где у категории свой лимит ещё не
-        # выбран (или его нет вовсе). 0 → ветка «мест нет» в шаблоне.
         race_full = race_remaining is not None and race_remaining <= 0
         for cat in categories:
             cat.people = cat.people_count()
             if race_full:
+                # Когда исчерпан лимит всей гонки, регистрация невозможна ни в одной
+                # категории — форсируем ``remaining = 0`` во всех категориях, чтобы
+                # бейдж показал «мест нет» даже там, где у категории свой лимит ещё не
+                # выбран (или его нет вовсе). 0 → ветка «мест нет» в шаблоне.
                 cat.remaining = 0
             else:
                 cat.remaining = (


### PR DESCRIPTION
The per-category "осталось N из M" badge on /race/<slug>/ only looked at each category's own people_limit, so it kept showing free slots even when the race-level limit was exhausted and registration was impossible.

RacePageView.build_context now forces cat.remaining = 0 for every category once race.remaining_people() hits 0, making the existing template branch render "мест нет" — including categories without their own limit.