### PR TITLE
Redirect to next (or home) after registration; add next= to login menu link

### DIFF
--- a/src/apps/accounts/tests.py
+++ b/src/apps/accounts/tests.py
@@ -810,3 +810,43 @@ def test_add_team_passwordless_round_trip_lands_back_on_add_team(client):
     assert resp.status_code == 302
     assert resp.url == add_url
     assert _is_logged_in(client)
+
+
+def _reg_post_data(**overrides):
+    data = {
+        "first_name": "Иван",
+        "last_name": "Петров",
+        "email": "newreg@example.com",
+        "phone": "+70000000000",
+        "password": "s3cret-pass",
+        "agree_privacy": "on",
+    }
+    data.update(overrides)
+    return data
+
+
+@pytest.mark.django_db
+def test_register_without_next_redirects_home(client):
+    resp = client.post(reverse("register"), _reg_post_data())
+    assert resp.status_code == 302
+    assert resp.url == "/"
+    assert _is_logged_in(client)
+
+
+@pytest.mark.django_db
+def test_register_honors_next(client):
+    resp = client.post(
+        reverse("register"), _reg_post_data(next="/race/some-race/teams/")
+    )
+    assert resp.status_code == 302
+    assert resp.url == "/race/some-race/teams/"
+    assert _is_logged_in(client)
+
+
+@pytest.mark.django_db
+def test_register_off_host_next_falls_back_home(client):
+    resp = client.post(
+        reverse("register"), _reg_post_data(next="https://evil.example.com/phish")
+    )
+    assert resp.status_code == 302
+    assert resp.url == "/"

--- a/src/apps/accounts/views.py
+++ b/src/apps/accounts/views.py
@@ -35,7 +35,6 @@ from apps.accounts.forms import (
 )
 from apps.accounts.models import EmailVerification
 from website.models import Race
-from website.models.race import RegStatus
 
 logger = logging.getLogger(__name__)
 
@@ -189,17 +188,8 @@ class RegisterView(View):
 
             # A guest who started from a login-gated page (e.g. «Войти и
             # добавить команду») carries ?next= through login → register; honor
-            # it so they land back where they came from.
-            if next_url:
-                return _safe_redirect(request, next_url)
-
-            # todo change it in 2026
-            race = Race.objects.filter(id=8).first()  # 2025
-            if race is None:
-                return HttpResponseRedirect("/")
-            if race.reg_status == RegStatus.OPEN:
-                return HttpResponseRedirect(reverse("add_team", args=[race.slug]))
-            return HttpResponseRedirect(reverse("my_teams", args=[race.slug]))
+            # it so they land back where they came from, otherwise go home.
+            return _safe_redirect(request, next_url or "/")
 
         return render(
             request,

--- a/src/templates/website/base-2.html
+++ b/src/templates/website/base-2.html
@@ -67,7 +67,7 @@
                     </div>
                 </div>
                 {% else %}
-                <a class="login" href="{% url 'login' %}">Войти</a>
+                <a class="login" href="{% url 'login' %}?next={{ request.get_full_path|urlencode }}">Войти</a>
                 {% endif %}
             </div>
         </div>

--- a/src/templates/website/base.html
+++ b/src/templates/website/base.html
@@ -70,7 +70,7 @@
                             </li>
                             {% else %}
                             <li class="nav-item">
-                                <a href="{% url 'login' %}" class="nav-link">Войти</a>
+                                <a href="{% url 'login' %}?next={{ request.get_full_path|urlencode }}" class="nav-link">Войти</a>
                             </li>
                             {% endif %}
                         </ul>


### PR DESCRIPTION
Drop the hardcoded fallback to Race id=8 after registration — land on next or home instead. Add ?next=<current page> to the «Войти» menu links in both base templates so login returns the user where they were.