### PR TITLE
fix: pad mobile team roster with empty member slots

### DIFF
--- a/src/apps/mobile/serializers.py
+++ b/src/apps/mobile/serializers.py
@@ -138,26 +138,44 @@ class TeamSerializer(serializers.ModelSerializer):
     set is empty it falls back to the legacy ``athlet1..6`` columns that the
     existing web UI still writes to.  The fallback keeps
     member data visible until every team is stored in the ``Athlet`` table.
+
+    The roster is then padded with empty-name slots up to
+    ``min(floor(paid_people), ucount)`` so the app sees one slot per
+    participant the team actually paid for and declared, even when not every
+    name was entered (the web form leaves member-name fields optional). Names
+    are never dropped: if real members exceed that floor (stale data after a
+    size reduction), every named slot is still emitted. ``paid_people`` keeps
+    unpaid/just-registered teams from sprouting synthetic slots. An empty slot
+    is ``{"name": "", "number_in_team": i}`` — the app renders its own
+    placeholder.
     """
 
     category2 = serializers.IntegerField(source="category2_id")
     members = serializers.SerializerMethodField()
 
     def get_members(self, team):
-        # Prefer Athlet rows (ordering comes from the view's Prefetch).
+        # Collect real names keyed by slot. Prefer Athlet rows (ordering comes
+        # from the view's Prefetch); fall back to legacy athlet1..6 columns.
+        names = {}
         athlets = list(team.athlet_set.all())
         if athlets:
-            return MemberSerializer(athlets, many=True).data
-        # Fall back to legacy athlet1..6 columns.
-        # Cap at ucount so slots above the active roster (stale after a size
-        # reduction — the web form hides but does not clear those inputs) are
-        # not exposed.
-        result = []
-        for i in range(1, min(team.ucount, 6) + 1):
-            name = getattr(team, f"athlet{i}", "")
-            if name:
-                result.append({"name": name, "number_in_team": i})
-        return result
+            for a in athlets:
+                names[a.number_in_team] = a.name
+        else:
+            for i in range(1, 7):
+                name = getattr(team, f"athlet{i}", "")
+                if name:
+                    names[i] = name
+
+        # One slot per paid + declared participant; never drop a real member.
+        target = min(int(team.paid_people), team.ucount)
+        if names:
+            target = max(target, max(names))
+
+        return [
+            {"name": names.get(i, ""), "number_in_team": i}
+            for i in range(1, target + 1)
+        ]
 
     class Meta:
         model = Team

--- a/src/apps/mobile/tests.py
+++ b/src/apps/mobile/tests.py
@@ -1698,6 +1698,85 @@ def test_team_serializer_members_in_number_order(django_user_model):
 
 
 @pytest.mark.django_db
+def test_team_serializer_pads_empty_slots_to_paid_people(django_user_model):
+    """A team that paid for 6 but named 3 gets 6 slots, 4..6 empty."""
+    from apps.mobile.serializers import TeamSerializer
+    from website.models.models import Team
+
+    race, category = _make_race_with_category(slug="ser-pad")
+    user = django_user_model.objects.create_user(
+        username="ser-pad", email="ser-pad@example.com", password="x"
+    )
+    team = Team.objects.create(
+        owner=user,
+        category2=category,
+        teamname="Padded",
+        ucount=6,
+        paid_people=6,
+        athlet1="A",
+        athlet2="B",
+        athlet3="C",
+    )
+    data = TeamSerializer(team).data
+    assert [(m["number_in_team"], m["name"]) for m in data["members"]] == [
+        (1, "A"),
+        (2, "B"),
+        (3, "C"),
+        (4, ""),
+        (5, ""),
+        (6, ""),
+    ]
+
+
+@pytest.mark.django_db
+def test_team_serializer_caps_slots_at_ucount(django_user_model):
+    """paid_people above ucount is capped by the declared team size."""
+    from apps.mobile.serializers import TeamSerializer
+    from website.models.models import Team
+
+    race, category = _make_race_with_category(slug="ser-cap")
+    user = django_user_model.objects.create_user(
+        username="ser-cap", email="ser-cap@example.com", password="x"
+    )
+    team = Team.objects.create(
+        owner=user,
+        category2=category,
+        teamname="Capped",
+        ucount=5,
+        paid_people=6,
+        athlet1="A",
+    )
+    data = TeamSerializer(team).data
+    assert [m["number_in_team"] for m in data["members"]] == [1, 2, 3, 4, 5]
+    assert data["members"][0]["name"] == "A"
+    assert all(m["name"] == "" for m in data["members"][1:])
+
+
+@pytest.mark.django_db
+def test_team_serializer_never_drops_named_members(django_user_model):
+    """Named members beyond min(paid, ucount) are still emitted (stale data)."""
+    from apps.mobile.serializers import TeamSerializer
+    from website.models.models import Team
+
+    race, category = _make_race_with_category(slug="ser-keep")
+    user = django_user_model.objects.create_user(
+        username="ser-keep", email="ser-keep@example.com", password="x"
+    )
+    team = Team.objects.create(
+        owner=user,
+        category2=category,
+        teamname="Stale",
+        ucount=2,
+        paid_people=2,
+        athlet1="A",
+        athlet2="B",
+        athlet3="C",
+    )
+    data = TeamSerializer(team).data
+    assert [m["name"] for m in data["members"]] == ["A", "B", "C"]
+
+
+@pytest.mark.django_db
 def test_team_serializer_category2_null_when_unset(django_user_model):
     from apps.mobile.serializers import TeamSerializer
     from website.models.models import Team


### PR DESCRIPTION
The mobile teams endpoint returned only the members whose names were entered, so a team that paid for 6 but named 3 showed 3 members. Member name fields are optional in the web form, so named < paid is common.

Pad the roster with empty-name slots up to min(floor(paid_people), ucount): one slot per paid + declared participant, never dropping a named member that exceeds that floor. Unpaid teams stay empty (paid_people=0). ETags are unaffected (padding is deterministic from fields already folded into teams_version).