### PR TITLE
feat: add legend total_cost for mobile progress bar

### DIFF
--- a/src/apps/mobile/tests.py
+++ b/src/apps/mobile/tests.py
@@ -531,6 +531,7 @@ def test_legend_valid_signature_returns_200_with_fields_and_order(client, settin
     assert response.status_code == 200
     data = response.json()
     assert data["race"] == race.id
+    assert data["total_cost"] == 4  # 2 + 1 + 1 over all non-hidden КП
     assert data["tags"] == []
     assert [c["number"] for c in data["checkpoints"]] == [1, 2, 3]
     first = data["checkpoints"][0]
@@ -839,6 +840,52 @@ def test_legend_locked_cp_serves_enc_not_cleartext_open_serves_cleartext(
     assert "secret tree" not in body
     # ...but the open КП's cleartext does
     assert "open spot" in body
+
+    # total_cost folds in the locked КП's cost (4 + 2) as an aggregate only —
+    # the per-КП locked cost still isn't exposed (no "cost" key on the locked КП).
+    assert data["total_cost"] == 6
+
+
+@pytest.mark.django_db
+def test_legend_total_cost_sums_non_hidden_only(client, settings):
+    """total_cost = Σ cost over open + locked КП, excluding hidden КП."""
+    from website.models.checkpoint import Checkpoint
+    from website.models.race import Race
+
+    settings.MOBILE_APP_KEYS = {"test-v1": SECRET}
+    settings.MOBILE_APP_TS_WINDOW = 300
+
+    race = Race.objects.create(name="Totals race", slug="totals-race")
+    Checkpoint.objects.create(race=race, number=1, cost=3, description="open")
+    Checkpoint.objects.create(
+        race=race, number=2, cost=5, description="locked", is_legend_locked=True
+    )
+    Checkpoint.objects.create(
+        race=race, number=3, cost=99, description="hidden", type="hidden"
+    )
+
+    path = f"/app/race/{race.id}/legend/"
+    response = client.get(path, **_signed_headers("GET", path, SECRET))
+
+    assert response.status_code == 200
+    # 3 (open) + 5 (locked); the hidden КП's cost of 99 is excluded.
+    assert response.json()["total_cost"] == 8
+
+
+@pytest.mark.django_db
+def test_legend_total_cost_empty_race_is_zero(client, settings):
+    """An empty race yields total_cost == 0 (Sum None coalesced to 0)."""
+    from website.models.race import Race
+
+    settings.MOBILE_APP_KEYS = {"test-v1": SECRET}
+    settings.MOBILE_APP_TS_WINDOW = 300
+
+    race = Race.objects.create(name="Empty race", slug="empty-totals-race")
+    path = f"/app/race/{race.id}/legend/"
+    response = client.get(path, **_signed_headers("GET", path, SECRET))
+
+    assert response.status_code == 200
+    assert response.json()["total_cost"] == 0
 
 
 @pytest.mark.django_db

--- a/src/apps/mobile/versioning.py
+++ b/src/apps/mobile/versioning.py
@@ -103,8 +103,9 @@ def races_version():
 # Prefixed into every legend_version() hash so a schema change forces a cache
 # bust on all cached clients at deploy time, even when no DB row was touched.
 # History: 1 = initial; 2 = color field added to LegendCheckpointSerializer;
-# 3 = legend tags[] identity key renamed point -> checkpoint_id (TagSerializer).
-_LEGEND_SCHEMA_VERSION = 3
+# 3 = legend tags[] identity key renamed point -> checkpoint_id (TagSerializer);
+# 4 = top-level total_cost added to the legend response (progress-bar denominator).
+_LEGEND_SCHEMA_VERSION = 4
 
 
 def legend_version(race_id):

--- a/src/apps/mobile/views.py
+++ b/src/apps/mobile/views.py
@@ -11,7 +11,7 @@ import logging
 from django.conf import settings
 from django.contrib.auth import authenticate
 from django.db import IntegrityError, transaction
-from django.db.models import F, Prefetch
+from django.db.models import F, Prefetch, Sum
 from django.http import HttpResponseNotModified
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
@@ -375,9 +375,18 @@ class LegendView(AppAPIView):
             .exclude(bid="")
             .order_by("id")
         )
+        # Progress-bar denominator: the sum of `cost` over the same non-hidden
+        # КП the legend serves (open + locked). Sent in cleartext as an aggregate
+        # only — the per-КП cost of a locked КП still never leaves the server, so
+        # the legend lock (which hides strategic per-КП values) is preserved.
+        # `Sum` ignores order_by/select_related; an empty race yields None → 0.
+        # Derives purely from `Checkpoint.cost`, which `legend_version` already
+        # fingerprints via `MAX(updated_at)|COUNT`, so no new ETag input is needed.
+        total_cost = qs.aggregate(total=Sum("cost"))["total"] or 0
         resp = Response(
             {
                 "race": race_id,
+                "total_cost": total_cost,
                 "checkpoints": LegendCheckpointSerializer(qs, many=True).data,
                 "tags": TagSerializer(tag_qs, many=True).data,
             }


### PR DESCRIPTION
The mobile legend progress bar (e.g. 5/20 баллов) computed its total by summing cost over decrypted КП only, so a race with locked КП showed a wrong denominator — locked-but-unvisited КП were missing from the total.

Serve an aggregate total_cost at the legend response top level: the sum of cost over all non-hidden КП (open + locked). The per-КП cost of a locked КП still never leaves the server — only the aggregate — so the legend lock (which hides strategic per-КП values) is preserved.

No new ETag input: total_cost derives from Checkpoint.cost, already folded into legend_version via MAX(updated_at)|COUNT. Bump _LEGEND_SCHEMA_VERSION 3->4 for the response-shape cache bust.